### PR TITLE
Prevent false positives when the servers requests for an interactive login (SonicWall SSH)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0
 #
-# clang-format configuration file. Intended for clang-format >= 4.
+# clang-format configuration file. Intended for clang-format >= 11.
 #
 # For more information, see:
 #
@@ -13,7 +13,7 @@ AccessModifierOffset: -4
 AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false
-#AlignEscapedNewlines: Left # Unknown to clang-format-4.0
+AlignEscapedNewlines: Left
 AlignOperands: true
 AlignTrailingComments: false
 AllowAllParametersOfDeclarationOnNextLine: false
@@ -37,24 +37,24 @@ BraceWrapping:
   AfterObjCDeclaration: false
   AfterStruct: false
   AfterUnion: false
-  #AfterExternBlock: false # Unknown to clang-format-5.0
+  AfterExternBlock: false
   BeforeCatch: false
   BeforeElse: false
   IndentBraces: false
-  #SplitEmptyFunction: true # Unknown to clang-format-4.0
-  #SplitEmptyRecord: true # Unknown to clang-format-4.0
-  #SplitEmptyNamespace: true # Unknown to clang-format-4.0
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
 BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Custom
-#BreakBeforeInheritanceComma: false # Unknown to clang-format-4.0
+BreakBeforeInheritanceComma: false
 BreakBeforeTernaryOperators: false
 BreakConstructorInitializersBeforeComma: false
-#BreakConstructorInitializers: BeforeComma # Unknown to clang-format-4.0
+BreakConstructorInitializers: BeforeComma
 BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: false
 ColumnLimit: 80
 CommentPragmas: '^ IWYU pragma:'
-#CompactNamespaces: false # Unknown to clang-format-4.0
+CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 8
 ContinuationIndentWidth: 8
@@ -62,15 +62,15 @@ Cpp11BracedListStyle: false
 DerivePointerAlignment: false
 DisableFormat: false
 ExperimentalAutoDetectBinPacking: false
-#FixNamespaceComments: false # Unknown to clang-format-4.0
-
-#IncludeBlocks: Preserve # Unknown to clang-format-5.0
+FixNamespaceComments: false
+IncludeBlocks: Preserve
 IncludeCategories:
   - Regex: '.*'
     Priority: 1
 IncludeIsMainRegex: '(Test)?$'
-IndentCaseLabels: true
-#IndentPPDirectives: None # Unknown to clang-format-5.0
+IndentCaseLabels: false
+IndentGotoLabels: false
+IndentPPDirectives: None
 IndentWidth: 8
 IndentWrappedFunctionNames: false
 JavaScriptQuotes: Leave
@@ -79,14 +79,14 @@ KeepEmptyLinesAtTheStartOfBlocks: false
 MacroBlockBegin: ''
 MacroBlockEnd: ''
 MaxEmptyLinesToKeep: 1
-NamespaceIndentation: Inner
-#ObjCBinPackProtocolList: Auto # Unknown to clang-format-5.0
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
 ObjCBlockIndentWidth: 8
 ObjCSpaceAfterProperty: true
 ObjCSpaceBeforeProtocolList: true
 
 # Taken from git's rules
-#PenaltyBreakAssignment: 10 # Unknown to clang-format-4.0
+PenaltyBreakAssignment: 10
 PenaltyBreakBeforeFirstCallParameter: 30
 PenaltyBreakComment: 10
 PenaltyBreakFirstLessLess: 0
@@ -96,15 +96,15 @@ PenaltyReturnTypeOnItsOwnLine: 60
 
 PointerAlignment: Right
 ReflowComments: false
-SortIncludes: true
-#SortUsingDeclarations: false # Unknown to clang-format-4.0
+SortIncludes: false
+SortUsingDeclarations: false
 SpaceAfterCStyleCast: false
 SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
-#SpaceBeforeCtorInitializerColon: true # Unknown to clang-format-5.0
-#SpaceBeforeInheritanceColon: true # Unknown to clang-format-5.0
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
-#SpaceBeforeRangeBasedForLoopColon: true # Unknown to clang-format-5.0
+SpaceBeforeRangeBasedForLoopColon: true
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
 SpacesInAngles: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -6,8 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.0] - 2020-03-07
+### Fixed
+
+- Fixed static build
+- Fixed Array index out of bounds in detection.c
+
 ### Added
+
+- After a successful login checks for a non interactive command execution,
+in order to prevent false positives when the servers requests for an interactive
+login (SonicWall SSH)
+
+## [0.5.0] - 2020-03-07
+
+### Added
+
 - Support for custom port (argument: -p <PORT>) both on scan and bruteforce phases.
 - Dry-run (argument: -D)
 - Added the initial basis to support different ports on different targets
@@ -21,51 +35,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ignoring servers that don't support password authentication.
 
 ### Changed
+
 - Separate Cbrutekrag verbosity from SSHLIB verbosity. (arguments: -v and -V respectively).
 - The default maximum number of threads is calculated automatically.
 - Allow servers detected as honeypot (argument flag -A)
 - Improved detection of non-eligible servers.
 
 ### Removed
+
 - Removed port option (-p <port>) in favor of new targets syntax (191.168.0.0/24:2222)
 
 ### Fixed
+
 - Wait until all forks finished her work.
 - Ignore SIGPIPE
 - Fixed false positives in servers which login are interactive.
 
 ## [0.4.0] - 2018-09-02
+
 ### Added
+
 - Multithreaded port scan, discard targets from batch if the port is closed (argument: -s).
 - Honeypot detection (?).
 - Support for target list as arguments. It can be combined with targets file.
 - Targets can be a CIDR IPv4 block.
 
 ### Fixed
+
 - Initialize hostnames wordlist.
 - Aborts bruteforce phase if there is no targets after scan or honeypot detection phases.
 
 ## [0.3.0] - 2018-08-26
+
 ### Added
+
 - Compatibility with libssh-dev < 0.6.0.
 
 ### Changed
+
 - Improved logging.
 - Improved help (-h).
 
 ### Fixed
+
 - Fixed a segmentation fault when it does not had an open output file.
 - Update progress bar at the end to complete 100%.
 
 ## [0.2.1] - 2018-01-02
+
 ### Added
+
 - Support for empty password ($BLANKPASS in dictionary).
 
 ### Changed
+
 - Improved fork model.
 
 ## [0.1.3] - 2017-12-29
+
 ### Added
+
 - Multithread.
 - Progress bar.
 

--- a/include/log.h
+++ b/include/log.h
@@ -31,16 +31,16 @@ enum { LOG_TRACE,
        LOG_FATAL,
 };
 
-#define log_error(...)                                                         \
-	print_output(LOG_ERROR, __FILE__, __LINE__, "\033[91m", "\033[0m",     \
+#define log_error(...)                                                     \
+	print_output(LOG_ERROR, __FILE__, __LINE__, "\033[91m", "\033[0m", \
 		     stderr, __VA_ARGS__)
-#define log_warn(...)                                                          \
+#define log_warn(...) \
 	print_output(LOG_WARN, __FILE__, __LINE__, "", "", stderr, __VA_ARGS__)
 
-#define log_debug(...)                                                         \
-	print_output(LOG_DEBUG, __FILE__, __LINE__, "\033[37m", "\033[0m",     \
+#define log_debug(...)                                                     \
+	print_output(LOG_DEBUG, __FILE__, __LINE__, "\033[37m", "\033[0m", \
 		     stderr, __VA_ARGS__)
-#define log_info(...)                                                          \
+#define log_info(...) \
 	print_output(LOG_INFO, __FILE__, __LINE__, "", "", stdout, __VA_ARGS__)
 
 void print_output(int level, const char *file, int line, const char *head,

--- a/src/bruteforce_ssh.c
+++ b/src/bruteforce_ssh.c
@@ -67,8 +67,8 @@ int bruteforce_ssh_login(btkg_context_t *context, const char *hostname,
 	if (r != SSH_OK) {
 		ssh_free(my_ssh_session);
 		if (context->verbose & CBRUTEKRAG_VERBOSE_MODE) {
-			log_error("[!1] Error connecting to %s:%d (%d) %s.", hostname,
-				  port, ssh_get_error_code(my_ssh_session), ssh_get_error(my_ssh_session));
+			log_error("[!] Error connecting to %s:%d %s.", hostname,
+				  port, ssh_get_error(my_ssh_session));
 		}
 		return -1;
 	}
@@ -122,8 +122,9 @@ int bruteforce_ssh_login(btkg_context_t *context, const char *hostname,
 			ret = ssh_channel_request_exec(channel,
 						       "cat > /dev/null");
 			if (ret < 0) {
-				log_debug("[!] %s:%d - Possible interactive login (ie SonicWall).",
-					  hostname, port);
+				log_debug(
+					"[!] %s:%d - Possible interactive login (ie SonicWall).",
+					hostname, port);
 				ssh_channel_close(channel);
 				ssh_disconnect(my_ssh_session);
 				ssh_free(my_ssh_session);

--- a/src/cbrutekrag.c
+++ b/src/cbrutekrag.c
@@ -54,7 +54,7 @@ void print_banner()
 	       "\033[37m    | (__ \033[92m| |_) | |  | |_| | ||  __/   <| | | (_| | (_| |\n"
 	       "\033[37m     \\___|\033[92m|_.__/|_|   \\__,_|\\__\\___|_|\\_\\_|  \\__,_|\\__, |\n"
 	       "              \033[0m\033[1mOpenSSH Brute force tool 0.5.0\033[0m\033[92m        __/ |\n"
-	       "          \033[0m(c) Copyright 2014-2022 Jorge Matricali\033[92m  |___/\033[0m\n\n");
+	       "          \033[0m(c) Copyright 2014-2023 Jorge Matricali\033[92m  |___/\033[0m\n\n");
 }
 
 void usage(const char *p)
@@ -102,70 +102,70 @@ int main(int argc, char **argv)
 	setrlimit(RLIMIT_NOFILE, &limit);
 
 	/* Calculate maximun number of threads. */
-	context.max_threads =
-		(limit.rlim_cur > 1024) ? 1024 : limit.rlim_cur - 8;
+	context.max_threads = (limit.rlim_cur > 1024) ? 1024 :
+							limit.rlim_cur - 8;
 
 	while ((opt = getopt(argc, argv, "aAT:C:t:o:DsvVPh")) != -1) {
 		switch (opt) {
-			case 'a':
-				context.non_openssh = 1;
-				break;
-			case 'A':
-				context.allow_honeypots = 1;
-				break;
-			case 'v':
-				context.verbose |= CBRUTEKRAG_VERBOSE_MODE;
-				g_verbose = context.verbose;
-				break;
-			case 'V':
-				context.verbose |= CBRUTEKRAG_VERBOSE_SSHLIB;
-				break;
-			case 'T':
-				hostnames_filename = strdup(optarg);
-				break;
-			case 'C':
-				credentials_filename = strdup(optarg);
-				break;
-			case 't':
-				tempint = atoi(optarg);
-				if (tempint < 1) {
-					log_error("Invalid threads size. (%d)",
-						  tempint);
-					exit(EXIT_FAILURE);
-				}
-				context.max_threads = (size_t)tempint;
-				break;
-			case 'o':
-				output_filename = strdup(optarg);
-				break;
-			case 's':
-				context.perform_scan = 1;
-				break;
-			case 'D':
-				context.dry_run = 1;
-				break;
-			case 'P':
-				context.progress_bar = 1;
-				break;
-			case 'h':
-				print_banner();
-				usage(argv[0]);
-				printf("  -h                This help\n"
-				       "  -v                Verbose mode\n"
-				       "  -V                Verbose mode (sshlib)\n"
-				       "  -s                Scan mode\n"
-				       "  -D                Dry run\n"
-				       "  -P                Progress bar\n"
-				       "  -T <targets>      Targets file\n"
-				       "  -C <credentials>  Username and password file\n"
-				       "  -t <threads>      Max threads\n"
-				       "  -o <output>       Output log file\n"
-				       "  -a                Accepts non OpenSSH servers\n"
-				       "  -A                Allow servers detected as honeypots.\n");
-				exit(EXIT_SUCCESS);
-			default:
-				usage(argv[0]);
+		case 'a':
+			context.non_openssh = 1;
+			break;
+		case 'A':
+			context.allow_honeypots = 1;
+			break;
+		case 'v':
+			context.verbose |= CBRUTEKRAG_VERBOSE_MODE;
+			g_verbose = context.verbose;
+			break;
+		case 'V':
+			context.verbose |= CBRUTEKRAG_VERBOSE_SSHLIB;
+			break;
+		case 'T':
+			hostnames_filename = strdup(optarg);
+			break;
+		case 'C':
+			credentials_filename = strdup(optarg);
+			break;
+		case 't':
+			tempint = atoi(optarg);
+			if (tempint < 1) {
+				log_error("Invalid threads size. (%d)",
+					  tempint);
 				exit(EXIT_FAILURE);
+			}
+			context.max_threads = (size_t)tempint;
+			break;
+		case 'o':
+			output_filename = strdup(optarg);
+			break;
+		case 's':
+			context.perform_scan = 1;
+			break;
+		case 'D':
+			context.dry_run = 1;
+			break;
+		case 'P':
+			context.progress_bar = 1;
+			break;
+		case 'h':
+			print_banner();
+			usage(argv[0]);
+			printf("  -h                This help\n"
+			       "  -v                Verbose mode\n"
+			       "  -V                Verbose mode (sshlib)\n"
+			       "  -s                Scan mode\n"
+			       "  -D                Dry run\n"
+			       "  -P                Progress bar\n"
+			       "  -T <targets>      Targets file\n"
+			       "  -C <credentials>  Username and password file\n"
+			       "  -t <threads>      Max threads\n"
+			       "  -o <output>       Output log file\n"
+			       "  -a                Accepts non OpenSSH servers\n"
+			       "  -A                Allow servers detected as honeypots.\n");
+			exit(EXIT_SUCCESS);
+		default:
+			usage(argv[0]);
+			exit(EXIT_FAILURE);
 		}
 	}
 	print_banner();

--- a/src/detection.c
+++ b/src/detection.c
@@ -70,7 +70,7 @@ int detection_login_methods(btkg_context_t *context, const char *hostname,
 	ssh_options_set(session, SSH_OPTIONS_HOST, hostname);
 	ssh_options_set(session, SSH_OPTIONS_LOG_VERBOSITY, &verbosity);
 	ssh_options_set(session, SSH_OPTIONS_PORT, &port);
-#if LIBSSH_VERSION_MAYOR > 0 ||                                                \
+#if LIBSSH_VERSION_MAYOR > 0 || \
 	(LIBSSH_VERSION_MAYOR == 0 && LIBSSH_VERSION_MINOR >= 6)
 	ssh_options_set(session, SSH_OPTIONS_KEY_EXCHANGE, "none");
 	ssh_options_set(session, SSH_OPTIONS_HOSTKEYS, "none");
@@ -224,9 +224,11 @@ int detection_detect_ssh(btkg_context_t *ctx, const char *hostname,
 	}
 
 	banner_len = strcspn(buffer, "\r\n");
+
+	if (banner_len > BANNER_LEN)
+		banner_len = BANNER_LEN;
+
 	if (banner_len > 0) {
-		if (banner_len > BANNER_LEN)
-			banner_len = BANNER_LEN;
 		strncpy(banner, buffer, banner_len);
 		banner[banner_len - 1] = 0;
 	}

--- a/src/detection.c
+++ b/src/detection.c
@@ -228,7 +228,7 @@ int detection_detect_ssh(btkg_context_t *ctx, const char *hostname,
 		if (banner_len > BANNER_LEN)
 			banner_len = BANNER_LEN;
 		strncpy(banner, buffer, banner_len);
-		banner[banner_len] = 0;
+		banner[banner_len - 1] = 0;
 	}
 
 	if (strstr(banner, "SSH-") != banner) {


### PR DESCRIPTION
After a successful login checks for a non interactive command execution,
in order to prevent false positives when the servers requests for an interactive
login (SonicWall SSH)