### PR TITLE
Support for use hostname as password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Hostname can be used as a username or password dynamically ($TARGET)
+
 ### Fixed
 - Added missing wrapper for FD_SET in static build
 - ssh_get_error shouldnt be used after ssh_free

--- a/README.md
+++ b/README.md
@@ -93,5 +93,14 @@ cbrutekrag -s -t 8 -C combinations.txt -o result.log 192.168.1.0/24
 ```
 root root
 root password
-root $BLANKPASS$
+root $BLANKPASS
+$TARGET root
+root $TARGET
 ```
+
+#### Combinations file placeholders
+
+|Placeholder|Purpose|As password| As username|
+|------------|------|-----------|------------|
+|$BLANKPASS|Blank password|✔️|-|
+|$TARGET|Use hostname or IP as a password|✔️|✔️|

--- a/src/bruteforce_ssh.c
+++ b/src/bruteforce_ssh.c
@@ -22,6 +22,7 @@ SOFTWARE.
 
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 
 #include <libssh/libssh.h>
 
@@ -118,25 +119,30 @@ int bruteforce_ssh_try_login(btkg_context_t *context, const char *hostname,
 			     const char *password, size_t count, size_t total,
 			     FILE *output)
 {
+	const char *_password =
+		strcmp(password, "$TARGET") == 0 ? hostname : password;
+	const char *_username =
+		strcmp(username, "$TARGET") == 0 ? hostname : username;
+
 	int ret = bruteforce_ssh_login(context, hostname, port, username,
 				       password);
 
 	if (ret == 0) {
 		log_info("\033[32m[+]\033[0m %s:%d %s %s", hostname, port,
-			 username, password);
+			 _username, _password);
 		if (output != NULL) {
 			log_output(output, "\t%s:%d\t%s\t%s\n", hostname, port,
-				   username, password);
+				   _username, _password);
 		}
 	} else {
 		log_debug("\033[38m[-]\033[0m %s:%d %s %s", hostname, port,
-			  username, password);
+			  _username, _password);
 	}
 
 	if (context->progress_bar) {
 		char bar_suffix[50];
 		sprintf(bar_suffix, "[%zu] %s:%d %s %s", count, hostname, port,
-			username, password);
+			_username, _password);
 		progressbar_render(count, total, bar_suffix, 0);
 	}
 


### PR DESCRIPTION
Hostname can be used as a username or password dynamically ($TARGET) (#28)